### PR TITLE
Se muestra el corrector grupal correctamente

### DIFF
--- a/planilla.py
+++ b/planilla.py
@@ -71,6 +71,10 @@ def parse_notas(notas):
             correctores[grupo] = safely_get_column(row, DOCENTE_GRUP)
             grupos[grupo].add(padron)
 
+        # Información de las entregas grupales como alumnos individualmente.
+        padron = GRUPAL + padron        
+        correctores[padron] = safely_get_column(row, DOCENTE_GRUP)
+
     return correctores, grupos
 
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -184,6 +184,12 @@ function validatePadron(tp) {
   var valid = false;
   var corrector = null;
 
+  // Si la entrega es grupal, pero el identificador no es un grupo, el alumno entrega solo.
+  // Se corrige el padron para incluir 'g', y que el corrector que se muestre sea el correcto.
+  if (entregas[tp] === 'g' && !(padron.includes('G')) ){
+    padron = 'g' + padron
+  }
+
   if (padron in correctores && correctores[padron]) {
     corrector = correctores[padron];
     valid = true;


### PR DESCRIPTION
Se corrige que cuando se entrega individualmente una entrega grupal, se mostraba el corrector de las entregas individuales (en vez del corrector grupal)

Fixes #9 
