### PR TITLE
Añadir UI para registrar ausencias, a.k.a. “Estoy vivo”

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -87,27 +87,6 @@ document.addEventListener("DOMContentLoaded", function() {
 var correctores = JSON.parse('{{correctores_json|safe}}');
 var entregas = JSON.parse('{{entregas_json|safe}}');
 
-function invert(dict) {
-    var res = {};
-    var ks = Object.keys(dict);
-    for (var i = 0; i < ks.length; i++) {
-        var xs = dict[ks[i]];
-        for (var j = 0; j < xs.length; j++) {
-            res[xs[j]] = ks[i];
-        }
-    }
-    return res;
-}
-
-function clone(prefix, container) {
-  var id = prefix + $(container).children().length;
-  var newInput = $(container).children().last().clone();
-  newInput.val('');
-  newInput.attr('id', id);
-  newInput.attr('name', prefix);
-  newInput.appendTo($(container))
-}
-
 function validate() {
   var tp = validateTP();
   var padronValid = validatePadron(tp);

--- a/templates/index.html
+++ b/templates/index.html
@@ -15,7 +15,7 @@ Cada entrega quedará registrada.
   {% if alert %}<div class="alert alert-danger">{{ alert }}</div>{% endif %}
 
   <div class="form-group" id="fg_tp">
-    <label for="tp" class="col-xs-2 control-label">Entrega:</label>
+    <label for="tp" class="col-xs-2 control-label">Trabajo:</label>
     <div class="col-xs-4">
       <select class="form-control" name="tp" id="tp" value="">
         <option style="display:none" selected value></option>
@@ -36,6 +36,19 @@ Cada entrega quedará registrada.
       </p>
     </div>
   </div>
+  <div class="form-group" id="fg_tipo">
+    <label for="tipo" class="col-xs-2 control-label">Tipo de entrega:</label>
+    <div class="col-xs-4">
+      <div class="input-group">
+        <div class="radio">
+          <label><input type="radio" name="tipo" value="entrega" checked>Entrega de código</label>
+        </div>
+        <div class="radio">
+          <label><input type="radio" name="tipo" value="ausencia">Notificación de ausencia</label>
+        </div>
+      </div>
+    </div>
+  </div>
   <div class="form-group" id="fg_adjuntos">
     <label for="file" class="col-xs-2 control-label">Adjunto:</label>
     <div class="col-xs-4">
@@ -54,10 +67,10 @@ Cada entrega quedará registrada.
     </div>
   </div>
   <div class="form-group" id="fg_body">
-    <label for="body" class="col-xs-2 control-label">Mensaje (opcional):</label>
+    <label for="body" class="col-xs-2 control-label">Cambios realizados:</label>
     <div class="col-xs-4">
       <textarea class="form-control" name="body" id="body"></textarea>
-      <span class="help-block">Cualquier aclaración de utilidad para el corrector.</span>
+      <span class="help-block">(O cualquier otra aclaración.)</span>
     </div>
   </div>
   <div class="form-group">
@@ -78,10 +91,12 @@ Cada entrega quedará registrada.
 document.addEventListener("DOMContentLoaded", function() {
   $('#tp').on('input', validate);
   $('#identificador').on('input', validate);
+  $('input[name=tipo]:radio', '#fg_tipo').change(validate);
   $('#file').change(function() {
     $('#filename').val(this.files[0].name);
     validate();
   });
+  $('#body').change(validate);  // Verifica solo al perder focus.
 });
 
 var correctores = JSON.parse('{{correctores_json|safe}}');
@@ -91,8 +106,18 @@ function validate() {
   var tp = validateTP();
   var padronValid = validatePadron(tp);
   var filesValid = validateFiles();
-  var valid = !!tp && padronValid && filesValid;
+  var ausenciaValid = validateAusencia();
+  var valid = !!tp && padronValid && (filesValid || ausenciaValid);
   $('#submit').prop('disabled', !valid);
+}
+
+function validateAusencia() {
+  var value = $('input[name=tipo]:checked', '#fg_tipo').val();
+  var isAusencia = value == 'ausencia';
+  $('#file').prop('disabled', isAusencia);
+  $('span.btn', '#fg_adjuntos').toggleClass('disabled', isAusencia);
+  $('#fg_body label').html(isAusencia ? 'Justificación:' : 'Cambios realizados:');
+  return isAusencia && $('#body').val().trim().length > 0;
 }
 
 function validateTP() {

--- a/templates/index.html
+++ b/templates/index.html
@@ -37,7 +37,7 @@ Cada entrega quedará registrada.
     </div>
   </div>
   <div class="form-group" id="fg_adjuntos">
-    <label for="file0" class="col-xs-2 control-label">Adjunto:</label>
+    <label for="file" class="col-xs-2 control-label">Adjunto:</label>
     <div class="col-xs-4">
       <div class="input-group">
         <label class="input-group-btn">


### PR DESCRIPTION
Se añade a la página de entregas un selector “Tipo de entrega”, con dos opciones:

  * Entrega de código
  * Notificación de ausencia

En el primer caso, el workflow permanece igual.

Caso de elegir la segunda opción, se deshabilita la selección de archivo adjunto, y se reutiliza el textarea existente para escribir el mensaje (cambiando la descripción del área de texto a “Justificación”).

La coordinación con el corrector se realiza mediante la inclusión en el asunto de la keyword `(ausencia)`, ver algoritmos-rw/corrector#37.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/algoritmos-rw/algo2_sistema_entregas/29)
<!-- Reviewable:end -->
