### PR TITLE
Arrancar el timer de la planilla en main.py to play nice with logs.

### DIFF
--- a/main.py
+++ b/main.py
@@ -22,10 +22,13 @@ from werkzeug.exceptions import FailedDependency, HTTPException
 from werkzeug.utils import secure_filename
 
 from config import load_config, Modalidad, Settings
-from planilla import fetch_planilla
+from planilla import fetch_planilla, timer_planilla
 
-app = Flask(__name__)
+app = Flask("entregas")
+app.logger.setLevel(logging.INFO)
 cfg: Settings = load_config()
+
+timer_planilla.start()
 
 File = collections.namedtuple('File', ['content', 'filename'])
 EXTENSIONES_ACEPTADAS = {'zip', 'tar', 'gz', 'pdf'}


### PR DESCRIPTION
Idealmente, cualquier logging en la app usaría el mismo logger de Flask,
el cual puede accederse de manera global con logging.getLogger(). Pero
si la planilla arranca su timer nada más ser importado el módulo, no
habrá todavía logger de la app.

En este commit se mueve la llamada a timer_planilla.start() a main.py,
y se añade un logger.info() cada vez que se refresca en background. La
app de Flask se renombra a "entregas" para tener un nombre consistente
y descriptivo que pasar a getLogger().