### PR TITLE
Decidir desde la app la ruta del repo donde guardar los archivos

### DIFF
--- a/algorw/common/tasks.py
+++ b/algorw/common/tasks.py
@@ -1,3 +1,4 @@
+from pathlib import PurePath
 from typing import Dict, List, Optional
 
 from pydantic import BaseModel
@@ -20,3 +21,11 @@ class CorrectorTask(BaseModel):
     legajos: List[str]
     orig_headers: Dict[str, str]
     group_id: Optional[str] = None
+
+    # Ubicación de la entrega en el repo de entregas. A día de hoy el sistema
+    # de entregas elige la ruta, y el corrector guarda los archivos. Próximamente,
+    # el sistema de entregas guardará los archivos, y el corrector los leerá.
+    repo_relpath: PurePath
+
+    class Config:
+        arbitrary_types_allowed = True


### PR DESCRIPTION
Se añade el campo ‘repo_relpath’ a EntregaTask como manera de indicar
al corrector dónde guardar los archivos en algo2_entregas.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/algoritmos-rw/algo2_sistema_entregas/46)
<!-- Reviewable:end -->
