### PR TITLE
Cambios UI: siempre pedir legajo y confirmar si la entrega es grupal

### DIFF
--- a/main.py
+++ b/main.py
@@ -150,21 +150,22 @@ def post():
         files = get_files()
         body = request.form["body"] or ""
         tipo = request.form["tipo"]
-        identificador = request.form["identificador"]
+        legajo = request.form["legajo"]
+        modalidad = request.form["modalidad"]
     except KeyError as ex:
         raise InvalidForm(f"Formulario inválido sin campo {ex.args[0]!r}") from ex
 
     # Obtener alumnes que realizan la entrega.
     planilla = fetch_planilla()
     try:
-        alulist = planilla.get_alulist(identificador)
+        alumne = planilla.get_alu(legajo)
     except KeyError as ex:
-        raise InvalidForm(f"No se encuentra grupo o legajo {identificador!r}") from ex
+        raise InvalidForm(f"No se encuentra el legajo {legajo!r}") from ex
 
     # Validar varios aspectos de la entrega.
     if tp not in cfg.entregas:
         raise InvalidForm(f"La entrega {tp!r} es inválida")
-    elif len(alulist) > 1 and cfg.entregas[tp] != Modalidad.GRUPAL:
+    elif modalidad == "grupal" and cfg.entregas[tp] != Modalidad.GRUPAL:
         raise ValueError(f"La entrega {tp} debe ser individual")
     elif tipo == "entrega" and not files:
         raise InvalidForm("No se ha adjuntado ningún archivo con extensión válida.")
@@ -173,15 +174,22 @@ def post():
 
     # Encontrar a le docente correspondiente.
     if cfg.entregas[tp] == Modalidad.INDIVIDUAL:
-        docente = alulist[0].ayudante_indiv
+        docente = alumne.ayudante_indiv
     elif cfg.entregas[tp] == Modalidad.GRUPAL:
-        docente = alulist[0].ayudante_grupal
+        docente = alumne.ayudante_grupal
     else:
         docente = None
 
     if not docente and cfg.entregas[tp] != Modalidad.PARCIALITO:
-        legajos = ", ".join(x.legajo for x in alulist)
-        raise FailedDependency(f"No hay corrector para la entrega {tp} de {legajos}")
+        raise FailedDependency(f"No hay corrector para la entrega {tp} de {legajo}")
+
+    # Encontrar la lista de alumnes a quienes pertenece la entrega.
+    alulist = [alumne]
+    if modalidad == "grupal" and alumne.group:
+        try:
+            alulist = planilla.get_alulist(alumne.group)
+        except KeyError:
+            logging.warn(f"KeyError in get_alulist({alumne.group})")
 
     email = make_email(tp.upper(), alulist, docente, body)
     legajos = utils.sorted_strnum([x.legajo for x in alulist])

--- a/main.py
+++ b/main.py
@@ -151,9 +151,11 @@ def post():
         body = request.form["body"] or ""
         tipo = request.form["tipo"]
         legajo = request.form["legajo"]
-        modalidad = request.form["modalidad"]
+        modalidad = Modalidad(request.form.get("modalidad", "i"))
     except KeyError as ex:
         raise InvalidForm(f"Formulario inválido sin campo {ex.args[0]!r}") from ex
+    except ValueError as ex:
+        raise InvalidForm(f"Formulario con campo inválido: {ex.args[0]}") from ex
 
     # Obtener alumnes que realizan la entrega.
     planilla = fetch_planilla()
@@ -165,7 +167,9 @@ def post():
     # Validar varios aspectos de la entrega.
     if tp not in cfg.entregas:
         raise InvalidForm(f"La entrega {tp!r} es inválida")
-    elif modalidad == "grupal" and cfg.entregas[tp] != Modalidad.GRUPAL:
+    elif (modalidad == Modalidad.GRUPAL and cfg.entregas[tp] != Modalidad.GRUPAL) or (
+        modalidad != Modalidad.GRUPAL and cfg.entregas[tp] == Modalidad.GRUPAL
+    ):
         raise ValueError(f"La entrega {tp} debe ser individual")
     elif tipo == "entrega" and not files:
         raise InvalidForm("No se ha adjuntado ningún archivo con extensión válida.")

--- a/templates/index.html
+++ b/templates/index.html
@@ -14,6 +14,17 @@ Cada entrega quedará registrada.
 <form class="form-horizontal" role="form" method="post" enctype="multipart/form-data">
   {% if alert %}<div class="alert alert-danger">{{ alert }}</div>{% endif %}
 
+  <div class="form-group" id="fg_legajo">
+    <label for="legajo" class="col-xs-2 control-label">Legajo:</label>
+    <div class="col-xs-4">
+      <div class="input-group">
+        <input type="text" class="form-control" name="legajo" id="legajo" value="" placeholder="Legajo o padrón">
+        <span class="input-group-addon"></span>
+      </div>
+      <p class="help-block">
+      </p>
+    </div>
+  </div>
   <div class="form-group" id="fg_tp">
     <label for="tp" class="col-xs-2 control-label">Trabajo:</label>
     <div class="col-xs-4">
@@ -25,15 +36,22 @@ Cada entrega quedará registrada.
       </select>
     </div>
   </div>
-  <div class="form-group" id="fg_identificador">
-    <label for="identificador" class="col-xs-2 control-label">Identificador:</label>
+  <div class="form-group" id="fg_modalidad">
+    <label for="modalidad" class="col-xs-2 control-label">Modalidad:</label>
     <div class="col-xs-4">
       <div class="input-group">
-        <input type="text" class="form-control" name="identificador" id="identificador" value="" placeholder="Identificador">
-        <span class="input-group-addon"></span>
+        <div class="radio">
+          <label><input type="radio" name="modalidad" value="individual">Entrega individual</label>
+        </div>
+        <div class="radio">
+          <label><input type="radio" name="modalidad" value="grupal">Entrega para el grupo:
+            <select class="form-inline" placeholder="Grupo" name="grupo_id" id="grupo_id">
+              <!-- De momento este select es informacional, y main.py nunca lo lee. -->
+              <option value="" disabled selected>--</option>
+            </select>
+            <label for="grupo_id" class="sr-only">Grupo</label></label>
+        </div>
       </div>
-      <p class="help-block">
-      </p>
     </div>
   </div>
   <div class="form-group" id="fg_tipo">
@@ -90,7 +108,7 @@ Cada entrega quedará registrada.
 <script>
 document.addEventListener("DOMContentLoaded", function() {
   $('#tp').on('input', validate);
-  $('#identificador').on('input', validate);
+  $('#legajo').on('input', validate);
   $('input[name=tipo]:radio', '#fg_tipo').change(validate);
   $('#file').change(function() {
     $('#filename').val(this.files[0].name);
@@ -104,10 +122,31 @@ var correctores = {{ correctores | tojson }};
 
 function validate() {
   var tp = validateTP();
-  var padronValid = validatePadron(tp);
+  var legajo = validateLegajo();
   var filesValid = validateFiles();
   var ausenciaValid = validateAusencia();
-  var valid = !!tp && padronValid && (filesValid || ausenciaValid);
+  var valid = !!tp && !!legajo && (filesValid || ausenciaValid);
+  var grupo = "--";
+
+  if (tp && legajo && correctores[legajo]) {
+    // Mostrar nombre de docente y, si aplica, número de grupo.
+    let data = correctores[legajo];
+    var corrector = null;
+
+    if (entregas[tp] === 'i' && data[0]) {
+      corrector = data[0];
+    } else if (entregas[tp] === 'g' && data[1]) {
+      grupo = data[2];
+      corrector = data[1];
+    }
+
+    if (corrector) {
+      let input = $('#legajo');
+      input.parent().find('span').html('<b>Corrector:</b> ' + corrector);
+    }
+  }
+
+  $('#grupo_id option:selected').text(grupo);
   $('#submit').prop('disabled', !valid);
 }
 
@@ -126,57 +165,27 @@ function validateTP() {
   $('#tp').parent().toggleClass('has-success', valid);
 
   if (!valid) {
-    return tp;
+    return null;
   }
 
-  if (entregas[tp] === 'i') { // individual
-    $('#fg_identificador label').html('Padrón:');
-    $('#fg_identificador .help-block').html('Número de padrón');
-    $('#identificador').attr('placeholder', 'Padrón');
-  } else { // grupal
-    $('#fg_identificador label').html('Padrón o grupo:');
-    $('#fg_identificador .help-block').html('Número de padrón o identificador del grupo (ejemplo: "G04")');
-    $('#identificador').attr('placeholder', 'Padrón o número de grupo');
-  }
+  let es_grupal = entregas[tp] === 'g';
+
+  $('[name="modalidad"]').prop('disabled', !es_grupal);
+  $('[name="modalidad"]').val([es_grupal ? 'grupal' : 'individual']);
 
   return tp;
 }
 
-function validatePadron(tp) {
-  var input = $('#identificador');
-  var padron = validateAlNum(input);
+function validateLegajo() {
+  let input = $('#legajo');
+  let legajo = validateAlNum(input);
+  let is_valid = legajo && legajo in correctores;
+  let message = is_valid ? '<b>Padrón válido</b>' : '';
 
-  if(!padron) {
-    input.parent().find('span').html('');
-    input.parent().toggleClass('has-success', false);
-    return false;
-  }
+  input.parent().find('span').html(message);
+  input.parent().toggleClass('has-success', is_valid);
 
-  var valid = false;
-  var corrector = null;
-
-  // Si la entrega es grupal, pero el identificador no es un grupo, el alumno entrega solo.
-  // Se corrige el padron para incluir 'g', y que el corrector que se muestre sea el correcto.
-  if (entregas[tp] === 'g' && !(padron.includes('G')) ){
-    padron = 'g' + padron
-  }
-
-  if (padron in correctores && correctores[padron]) {
-    corrector = correctores[padron];
-    valid = true;
-  }
-
-  input.parent().find('span').html(corrector ? '<b>Corrector:</b> ' + corrector : '');
-  input.parent().toggleClass('has-success', !!corrector);
-
-  if(!valid && padron in correctores) {
-    // Aún no tiene un corrector asignado.
-    input.parent().find('span').html('<b>Identificador válido</b>');
-    input.parent().toggleClass('has-success', true);
-    valid = true;
-  }
-
-  return valid;
+  return is_valid ? legajo : null;
 }
 
 function validateFiles() {

--- a/templates/index.html
+++ b/templates/index.html
@@ -41,15 +41,15 @@ Cada entrega quedará registrada.
     <div class="col-xs-4">
       <div class="input-group">
         <div class="radio">
-          <label><input type="radio" name="modalidad" value="individual">Entrega individual</label>
+          <label><input type="radio" name="modalidad" value="i">Entrega individual</label>
         </div>
         <div class="radio">
-          <label><input type="radio" name="modalidad" value="grupal">Entrega para el grupo:
-            <select class="form-inline" placeholder="Grupo" name="grupo_id" id="grupo_id">
+          <label><input type="radio" name="modalidad" value="g">Entrega para el grupo:
+            <select class="form-inline" placeholder="Grupo" name="grupo" id="grupo">
               <!-- De momento este select es informacional, y main.py nunca lo lee. -->
               <option value="" disabled selected>--</option>
             </select>
-            <label for="grupo_id" class="sr-only">Grupo</label></label>
+            <label for="grupo" class="sr-only">Grupo</label></label>
         </div>
       </div>
     </div>
@@ -146,7 +146,7 @@ function validate() {
     }
   }
 
-  $('#grupo_id option:selected').text(grupo);
+  $('#grupo option:selected').text(grupo);
   $('#submit').prop('disabled', !valid);
 }
 
@@ -171,7 +171,7 @@ function validateTP() {
   let es_grupal = entregas[tp] === 'g';
 
   $('[name="modalidad"]').prop('disabled', !es_grupal);
-  $('[name="modalidad"]').val([es_grupal ? 'grupal' : 'individual']);
+  $('[name="modalidad"]').val([es_grupal ? 'g' : 'i']);
 
   return tp;
 }


### PR DESCRIPTION
Con vistas a definir con precisión a qué repositorio se debe importar
el código (ver #49), en este commit se comienza por:

  - siempre pedir el legajo a la persona que está subiendo el código

  - para entregas grupales, hacer explícita la elección de si el código
    se sube a título individual, o grupal (antes esto iba implícito según
    se usase padrón o número de grupo como identificador)

Cambios en la UI:

  - se renombra el campo Identificador, a Legajo (el número de grupo
    se muestra, si lo hay, pero nunca se pregunta explícitamente)

  - se introduce un selector "radio" que, para trabajos grupales,
    permite cambiar la modalidad a entrega a título personal.

Refactorings internos:

  - el JSON de correctores que se envía a index.html pasa a tener
    como claves solamente legajos (eliminando claves GXX y gYYYY);
    los valores son ahora un arreglo que especifica correctores
    (individual y grupal), y número de grupo.

    Esto facilita poder seguir mostrando los nombres de corrector,
    y además saber en O(1) el número de grupo asociado a un legajo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/algoritmos-rw/algo2_sistema_entregas/54)
<!-- Reviewable:end -->
