### PR TITLE
Permitir entregas individuales (y grupales) sin docente asignado

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,7 +15,7 @@ import requests
 
 from flask import Flask, render_template, request
 from flask_caching import Cache  # type: ignore
-from werkzeug.exceptions import FailedDependency, HTTPException
+from werkzeug.exceptions import HTTPException
 from werkzeug.utils import secure_filename
 
 from algorw import utils
@@ -178,15 +178,16 @@ def post():
         raise InvalidForm("No se ha adjuntado una justificación para la ausencia.")
 
     # Encontrar a le docente correspondiente.
+    docente = None
+    warning = None
+
     if cfg.entregas[tp] == Modalidad.INDIVIDUAL:
         docente = alumne.ayudante_indiv
     elif cfg.entregas[tp] == Modalidad.GRUPAL:
         docente = alumne.ayudante_grupal
-    else:
-        docente = None
 
     if not docente and cfg.entregas[tp] != Modalidad.PARCIALITO:
-        raise FailedDependency(f"No hay corrector para la entrega {tp} de {legajo}")
+        warning = "aún no se asignó docente para corregir esta entrega"
 
     # Encontrar la lista de alumnes a quienes pertenece la entrega, y su repo asociado.
     alulist = [alumne]
@@ -249,6 +250,7 @@ def post():
     return render_template(
         "result.html",
         tp=tp,
+        warning=warning,
         email="\n".join(f"{k}: {v}" for k, v in email.items()) if cfg.test else None,
     )
 


### PR DESCRIPTION
Es necesario aceptar la entrega aun si no hay docente asignado para
la corrección, particularmente en el caso del TP0 (que no hay _ninguna_
asignación).

El comportamiento se cambió inadvertidamente en ec498f4 (“Versión de la
planilla con mayor validación y dataclasses tipadas”). La validación
existente, que era:

https://github.com/algoritmos-rw/algo2_sistema_entregas/blob/003792995/main.py#L267-L273

se mantuvo intacta:

https://github.com/algoritmos-rw/algo2_sistema_entregas/blob/ec498f4e4/main.py#L236-L246

excepto que la planilla antigua _siempre_ asignaba un corrector en el
diccionario, para cada alumne. En particular, asignaba la cadena vacía
como corrector, si no había uno asignado. Por tanto, en realidad, la
validación antigua nunca fallaba.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/algoritmos-rw/algo2_sistema_entregas/58)
<!-- Reviewable:end -->
