### PR TITLE
Fixes para entregas individuales de TPs grupales

### DIFF
--- a/main.py
+++ b/main.py
@@ -168,9 +168,7 @@ def post():
     # Validar varios aspectos de la entrega.
     if tp not in cfg.entregas:
         raise InvalidForm(f"La entrega {tp!r} es inválida")
-    elif (modalidad == Modalidad.GRUPAL and cfg.entregas[tp] != Modalidad.GRUPAL) or (
-        modalidad != Modalidad.GRUPAL and cfg.entregas[tp] == Modalidad.GRUPAL
-    ):
+    elif modalidad == Modalidad.GRUPAL and cfg.entregas[tp] != Modalidad.GRUPAL:
         raise ValueError(f"La entrega {tp} debe ser individual")
     elif tipo == "entrega" and not files:
         raise InvalidForm("No se ha adjuntado ningún archivo con extensión válida.")

--- a/templates/index.html
+++ b/templates/index.html
@@ -168,10 +168,17 @@ function validateTP() {
     return null;
   }
 
+  // Seleccionar automáticamente modalidad individual o grupal pero, para
+  // trabajos grupales, solo si no había ya una selección (para permitir
+  // entregas individuales de TPs grupales).
   let es_grupal = entregas[tp] === 'g';
+  let esta_enabled = $('input:radio[name="modalidad"]').is(":enabled");
+  let hay_seleccion = $('input:radio[name="modalidad"]').is(":checked");
 
-  $('[name="modalidad"]').prop('disabled', !es_grupal);
-  $('[name="modalidad"]').val([es_grupal ? 'g' : 'i']);
+  if (!es_grupal || !hay_seleccion || !esta_enabled) {
+    $('input:radio[name="modalidad"]').prop('disabled', !es_grupal);
+    $('input:radio[name="modalidad"]').val([es_grupal ? 'g' : 'i']);
+  }
 
   return tp;
 }


### PR DESCRIPTION
Se corrigen dos cosas:

  - en las validaciones de index.html, no dejar que se cambie la modalidad
    de individual a grupal si ya había sido cambiada a mano

  - en las validaciones de main.py, permitir Modalidad.INDIVIDUAL para
    para trabajos grupales

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/algoritmos-rw/algo2_sistema_entregas/62)
<!-- Reviewable:end -->
