### PR TITLE
Incluir en los commits la descripción de cambios de la entrega

### DIFF
--- a/algorw/common/tasks.py
+++ b/algorw/common/tasks.py
@@ -48,6 +48,9 @@ class CorrectorTask(BaseModel):
     # el sistema de entregas guardará los archivos, y el corrector los leerá.
     repo_relpath: PurePath
 
+    # Descripción de los cambios (para el commit en el repositorio de entregas).
+    commit_desc: str
+
     # Sincronización a repositorios de alumnes.
     repo_sync: Optional[RepoSync] = None
 

--- a/algorw/corrector/alu_repos.py
+++ b/algorw/corrector/alu_repos.py
@@ -20,6 +20,10 @@ from github.GitTree import GitTree as GithubTree
 from github.Repository import Repository as GithubRepo
 
 
+# Se saca el emoji de la sincronización porque ya hay checkruns que indican el resultado
+EMOJI_REGEX = re.compile("^:(heavy_check_mark|x): ")
+
+
 class AluRepo:
     """Clase para sincronizar un repo de alumne.
     """
@@ -159,7 +163,7 @@ class AluRepo:
             )
             cur_tree = repo.create_git_tree(tree_elements, cur_tree)
             cur_commit = repo.create_git_commit(
-                commit.message, cur_tree, [cur_commit], author_info
+                EMOJI_REGEX.sub("", commit.message), cur_tree, [cur_commit], author_info
             )
             # Se necesita obtener el árbol de manera recursiva para tener
             # los contenidos del subdirectorio de la entrega.

--- a/algorw/corrector/corrector.py
+++ b/algorw/corrector/corrector.py
@@ -40,6 +40,7 @@ import shutil
 import subprocess
 import sys
 import tarfile
+import textwrap
 import zipfile
 
 from typing import Dict
@@ -112,7 +113,9 @@ def procesar_entrega(task: CorrectorTask):
     zip_obj = zipfile.ZipFile(io.BytesIO(task.zipfile))
     skel_dir = SKEL_DIR / tp_id
     moss = Moss(DATA_DIR / task.repo_relpath)
-    commit_message = f"New {tp_id} upload from {padron}"
+    # TODO: componer el mensaje entero desde main.py
+    commit_message = f"New {tp_id} upload from {padron}\n\n"
+    commit_message += textwrap.fill(task.commit_desc, 72)
 
     if AUSENCIA_REGEX.search(subj):
         # No es una entrega real, por tanto no se envía al worker.

--- a/main.py
+++ b/main.py
@@ -212,8 +212,10 @@ def post():
         with zipfile.ZipFile(rawzip, "w") as zf:
             zf.writestr("ausencia.txt", body + "\n")
         entrega = File(rawzip.getvalue(), f"{tp}_ausencia.zip")
+        commit_desc = ""
     else:
         entrega = zipfile_for_entrega(files)
+        commit_desc = body.strip()
 
     # Incluir el único archivo ZIP.
     part = MIMEBase("application", "zip")
@@ -254,6 +256,7 @@ def post():
         tp_id=tp_id,
         legajos=legajos,
         zipfile=entrega.content,
+        commit_desc=commit_desc,
         repo_sync=repo_sync,
         orig_headers=dict(email.items()),
         repo_relpath=relpath_base / "_".join(legajos),


### PR DESCRIPTION
El texto escrito en el textarea de la web se propaga ahora al repositorio
de entregas, y de ahí a los repositorios individuales y grupales.

Asimismo, se elimina el emoji de la sincronización, pues los checkruns
introducidos en #65 hacen exactamente el mismo trabajo ahora.

Closes: algoritmos-rw/corrector#41.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/algoritmos-rw/algo2_sistema_entregas/66)
<!-- Reviewable:end -->
