### PR TITLE
Use Python 3.8 for the linters workflow

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Python and pip caching
         uses: actions/setup-python@v2
         with:
-          python-version: '3.9'
+          python-version: '3.8'
           cache: pip
           cache-dependency-path: |
             requirements.txt


### PR DESCRIPTION
This is the version in Ubuntu 20.04, which we still use.
