### PR TITLE
Moss: borrar self._dest en el index

### DIFF
--- a/algorw/corrector/corrector.py
+++ b/algorw/corrector/corrector.py
@@ -271,6 +271,7 @@ class Moss:
         self._dest = dest
         self._emoji: Optional[str] = None
         shutil.rmtree(self._dest, ignore_errors=True)
+        self._git(["rm", "--cached", self._dest])
         self._dest.mkdir(parents=True)
 
     def location(self):


### PR DESCRIPTION
En versiones actuales de Git, al agregar un directorio que es a su vez un repo, se crea un "git submodule" en esa ubicación, y nuestro `shutil.rmtree` es insuficiente para remplazarlo. Para cubrir ese caso, este commit añade un `git rm --cached` tras `shutil.rmtree`. (N.B.: no puede usarse `git rm -r`,  pues el directorio no aparece en .gitmodules, y el comando da error.)

***

Este cambio está _live_ en lamport. Podemos hacer merge una vez confirmemos que funciona.