### PR TITLE
Agrego __MACOSX a los directorios skippeables, fix en casing de DS_Store

### DIFF
--- a/algorw/corrector/corrector.py
+++ b/algorw/corrector/corrector.py
@@ -225,7 +225,7 @@ def is_forbidden(path):
     )
 
 def is_skippable(path):
-    for ctx in [".git", ".DS_STORE"]:
+    for ctx in [".git", ".DS_Store", "__MACOSX"]:
         if ctx in path.parts:
             return True
     return False


### PR DESCRIPTION
Con esto debería skippearse el directorio completo y dejar de aparecer el error como si la entrega estuviera hecha en windows (por los archivos que se terminan generando dentro con extensión `.go`), que siempre termina descolocando a alguno.
Si la idea es que no lo entreguen, podría ver de agregarse como `FORBIDDEN` directamente, pero al menos que quede claro que es por ese directorio.